### PR TITLE
ParseCpsl - 1) replace System.err.println to log.error; 2) "duplicate binding name" set to warn logging level

### DIFF
--- a/src/main/java/gate/jape/parser/ParseCpsl.jj
+++ b/src/main/java/gate/jape/parser/ParseCpsl.jj
@@ -736,7 +736,7 @@ SinglePhaseTransducer SinglePhaseTransducer(String javaimportblock) :
             else if(optionValueTok.image.equalsIgnoreCase("all"))
               t.setRuleApplicationStyle(ALL_STYLE);
             else
-              System.err.println(errorMsgPrefix(optionValueTok)+
+              log.error(errorMsgPrefix(optionValueTok)+
                 "ignoring unknown control strategy " + option +
                 " (should be brill, appelt, first, once or all)"
               );
@@ -842,7 +842,7 @@ Rule Rule(String phaseName, String currentImports) :
     {
       try { rulePriority=Integer.parseInt(priorityTok.image); }
       catch(NumberFormatException e) {
-        System.err.println(errorMsgPrefix(priorityTok)+
+        log.error(errorMsgPrefix(priorityTok)+
           "bad priority spec(" + priorityTok.image +
           "), rule(" + ruleName + ") - treating as 0");
         rulePriority=0;
@@ -872,7 +872,7 @@ Rule Rule(String phaseName, String currentImports) :
   	  // and check if each of them is mentioned in the list
   	  for (String type : set) {
   	  	if(!curSPT.hasInput(type)) {
-  	  	  System.err.println(errorMsgPrefix(null)+
+  	  	  log.error(errorMsgPrefix(null)+
   	  	    "Rule "+ruleNameTok.image+" contains unlisted annotation type " + type);
   	  	}
   	  }
@@ -933,8 +933,7 @@ LeftHandSide LeftHandSide() :
         try {
           lhs.addBinding(bindingName, cpe, bindingNameSet);
         } catch(JapeException e) {
-          System.err.println(errorMsgPrefix(null)+
-            "duplicate binding name " + bindingName +
+          log.warn("duplicate binding name " + bindingName +
             " - ignoring this binding! exception was: " + e.toString()
           );
         }
@@ -1027,7 +1026,7 @@ BasicPatternElement BasicPatternElement() :
       shortTok=<string>
     )
     {
-      System.err.println(errorMsgPrefix(shortTok)+
+      log.error(errorMsgPrefix(shortTok)+
         "string shorthand not supported yet, ignoring: " + shortTok.image
       );
     }
@@ -1079,7 +1078,7 @@ KleeneOperator KleeneOperator() :
         if (type != null)
             return new KleeneOperator(type);
         else {
-          System.err.println(errorMsgPrefix(kleeneOpTok)+
+          log.error(errorMsgPrefix(kleeneOpTok)+
               "ignoring uninterpretable Kleene op " + kleeneOpTok.image);
           return new KleeneOperator(KleeneOperator.Type.SINGLE);
         }
@@ -1213,7 +1212,7 @@ Pair AttrVal() :
           try {
             val.second = Long.valueOf(attrValTok.image);
           } catch(NumberFormatException e) {
-            System.err.println(errorMsgPrefix(attrValTok)+
+            log.error(errorMsgPrefix(attrValTok)+
               "couldn't parse integer " +
               attrValTok.image + " - treating as 0");
             val.second = new Long(0);
@@ -1229,14 +1228,14 @@ Pair AttrVal() :
           try {
             val.second = Double.valueOf(attrValTok.image);
           } catch(NumberFormatException e) {
-            System.err.println(errorMsgPrefix(attrValTok)+
+            log.error(errorMsgPrefix(attrValTok)+
               "couldn't parse float " +
               attrValTok.image + " - treating as 0.0");
             val.second = new Double(0.0);
           }
           break;
         default:
-          System.err.println(errorMsgPrefix(attrValTok)+
+          log.error(errorMsgPrefix(attrValTok)+
             "didn't understand type of " + attrValTok.image + ": ignoring"
           );
           val.second = new String("");


### PR DESCRIPTION
ParseCpsl - 1) replace System.err.println to log.error; 2) "duplicate binding name" set to warn logging level

1. It is good to be able to manage logging via logback settings instead of just printing to System.err.
2. "duplicate binding name" is not an error, actually. We have lots of complex rules that work perfectly but we have lots of these messages in the log that we would like to turn off via logback settings